### PR TITLE
Allow starting new instance of Emacs without killing current session

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@
     #+END_QUOTE
 
 ** Usage
-   It offers only one command ~restart-emacs~ which kills current Emacs session
+   It offers a command ~restart-emacs~ which kills current Emacs session
    and starts a new session.
 
    Additional arguments to be passed to the new instance can be specified using
@@ -59,6 +59,10 @@
 
    ~restart-emacs~ can restore frames on restart, right this is experimental and
     disabled by default to enable it set ~restart-emacs-restore-frames~ to ~t~.
+
+   There is also a second command ~restart-emacs-start-new-emacs~ which starts a
+   new session of Emacs without killing the current one. It takes the same arguments
+   as ~restart-emacs~.
 
 ** Compatibility
 *** Restarting GUI Emacs


### PR DESCRIPTION
I frequently use restart-emacs when testing modifications to my Emacs configuration. However, restarting is not always the best way to test changes, because if the changes are broken, then I no longer have a working Emacs session with which to fix them. It's better if I can start a new session to see if the changes work, before killing the original session if desired.

This PR implements a new user option `restart-emacs-inhibit-kill-p` which, if non-nil, tweaks the behavior of the `restart-emacs` function to start a new session instead of performing a restart. I have been using this feature for a few years via `el-patch` but figured it might be desired upstream.

Please let me know if additional changes or information are needed.