### PR TITLE
Call restart-emacs interactively

### DIFF
--- a/restart-emacs.el
+++ b/restart-emacs.el
@@ -448,7 +448,7 @@ When called non-interactively ARGS should be a list of arguments
 with which the new Emacs should be started."
   (interactive "P")
   (let ((restart-emacs--inhibit-kill-p t))
-    (restart-emacs args)))
+    (funcall-interactively 'restart-emacs args)))
 
 (provide 'restart-emacs)
 ;;; restart-emacs.el ends here


### PR DESCRIPTION
`restart-emacs-start-new-emacs` needs to call `restart-emacs` interactively or this [line](https://github.com/iqbalansari/restart-emacs/blob/master/restart-emacs.el#L416) won't return true when `restart-emacs-start-new-emacs` is invoked with prefix.